### PR TITLE
v2.1: chapter-aware nav, epilogue, interior polish, pebble finale

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,6 +87,18 @@ h6 {
   font-family: var(--font-heading);
 }
 
+/* Chapter label swap in the nav (homepage journey tracker) */
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/components/ChapterTracker.tsx
+++ b/src/components/ChapterTracker.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * Chapter-aware nav (Master_PRP §10.5, Phase 10).
+ *
+ * Homepage only: a thin scroll-progress line under the header and the
+ * current chapter label in mono, updating as the visitor moves through
+ * the journey. The chrome tells the story too. Renders nothing on
+ * other routes.
+ */
+
+const CHAPTERS: { id: string; label: string }[] = [
+  { id: "scene-hero", label: "PROLOGUE · THE SYSTEM" },
+  { id: "scene-security", label: "CH.1 · SECURITY" },
+  { id: "scene-monolith", label: "CH.2 · ARCHITECTURE" },
+  { id: "scene-rag", label: "CH.3 · AI/RAG" },
+  { id: "scene-signal", label: "CH.4 · THE VENDOR CALL" },
+  { id: "scene-ship", label: "CH.5 · SCALE & SHIP" },
+  { id: "scene-now", label: "CH.6 · NOW" },
+  { id: "scene-projects", label: "EPILOGUE · SIDE PROJECTS" },
+  { id: "scene-contact", label: "THE NEXT CHAPTER" },
+];
+
+export const ChapterLabel = () => {
+  const pathname = usePathname();
+  const [label, setLabel] = useState(CHAPTERS[0].label);
+
+  useEffect(() => {
+    if (pathname !== "/") return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const hit = CHAPTERS.find((c) => c.id === entry.target.id);
+            if (hit) setLabel(hit.label);
+          }
+        }
+      },
+      // A slim band around the viewport's upper-middle decides the chapter
+      { rootMargin: "-35% 0px -55% 0px" }
+    );
+
+    CHAPTERS.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) io.observe(el);
+    });
+    return () => io.disconnect();
+  }, [pathname]);
+
+  if (pathname !== "/") return null;
+
+  return (
+    <span
+      key={label}
+      className="hidden animate-[fadeSlideIn_0.4s_ease] font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground lg:block"
+    >
+      {label}
+    </span>
+  );
+};
+
+export const ScrollProgress = () => {
+  const pathname = usePathname();
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (pathname !== "/") return;
+    let raf = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const max = document.documentElement.scrollHeight - window.innerHeight;
+        setProgress(max > 0 ? Math.min(window.scrollY / max, 1) : 0);
+      });
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(raf);
+    };
+  }, [pathname]);
+
+  if (pathname !== "/") return null;
+
+  return (
+    <div className="absolute inset-x-0 bottom-0 h-px overflow-hidden" aria-hidden>
+      <div
+        className="h-full origin-left bg-gradient-to-r from-[#22d3ee] to-[#3b82f6]"
+        style={{ transform: `scaleX(${progress})` }}
+      />
+    </div>
+  );
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,10 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import { LuLinkedin, LuGithub } from "react-icons/lu";
 import { RiTwitterXLine } from "react-icons/ri";
 
-const SOCIALS = [
+export const SOCIALS = [
   {
     label: "LinkedIn",
     href: "https://www.linkedin.com/in/abdul-aziz-mohammed-87296b179",
@@ -20,7 +23,11 @@ const SOCIALS = [
 ];
 
 export default function Footer() {
+  const pathname = usePathname();
   const currentYear = new Date().getFullYear();
+
+  // The homepage journey carries its own finale footer inside ContactCTA
+  if (pathname === "/") return null;
 
   return (
     <footer className="relative z-10 border-t border-border bg-background px-4 py-6 sm:px-6 lg:px-8">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import NavbarItems from "../modules/home/components/NavbarItems";
+import { ChapterLabel, ScrollProgress } from "./ChapterTracker";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -36,10 +37,13 @@ const Header = () => {
           "relative flex items-center justify-between transition-all duration-300",
           scrolled ? "h-12" : "h-16"
         )}>
-          {/* Logo */}
-          <Link href="/" className="flex items-center justify-center">
-            <Image src="/images/logo.png" alt="Logo" width={28} height={28} priority />
-          </Link>
+          {/* Logo + current chapter (homepage only) */}
+          <div className="flex items-center gap-4">
+            <Link href="/" className="flex items-center justify-center">
+              <Image src="/images/logo.png" alt="Logo" width={28} height={28} priority />
+            </Link>
+            <ChapterLabel />
+          </div>
 
           {/* Nav links - absolutely centered */}
           <div className="absolute left-1/2 -translate-x-1/2 hidden md:block">
@@ -59,7 +63,7 @@ const Header = () => {
             type="button"
             onClick={() => setIsMenuOpen((o) => !o)}
             className="md:hidden p-2 -mr-2 rounded-md hover:bg-white/5 transition-colors"
-            aria-expanded={isMenuOpen ? "true" : "false"}
+            aria-expanded={isMenuOpen}
             aria-label="Toggle menu"
           >
             {isMenuOpen ? (
@@ -82,6 +86,9 @@ const Header = () => {
           <NavbarItems isMobile />
         </div>
       </div>
+
+      {/* Journey scroll progress (homepage only) */}
+      <ScrollProgress />
     </header>
   );
 };

--- a/src/modules/about/ui/AboutPage.tsx
+++ b/src/modules/about/ui/AboutPage.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Dumbbell,
   Mountain,
@@ -12,6 +14,7 @@ import {
   Check,
   type LucideIcon,
 } from "lucide-react";
+import MaskReveal from "@/modules/journey/components/MaskReveal";
 
 const INTERESTS: { icon: LucideIcon; label: string }[] = [
   { icon: Dumbbell, label: "Workouts & Health" },
@@ -47,12 +50,14 @@ const AboutPage = () => {
     <div className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
       {/* Header */}
       <div className="mb-16 max-w-2xl space-y-4">
-        <p className="font-mono text-sm uppercase tracking-widest text-muted-foreground">
-          About
+        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+          About · The person behind the PRs
         </p>
-        <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-          Beyond the code
-        </h1>
+        <MaskReveal>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+            Beyond the code
+          </h1>
+        </MaskReveal>
         <p className="text-base text-muted-foreground md:text-lg">
           I&apos;m Abdul Aziz - a software engineer based in Seattle, WA. I
           joined Agentnomics.ai in November 2025 and have been shipping
@@ -62,8 +67,8 @@ const AboutPage = () => {
       </div>
 
       {/* How I learn */}
-      <div className="mb-16 rounded-xl border border-border bg-surface p-6 md:p-8">
-        <p className="font-mono text-sm uppercase tracking-widest text-muted-foreground mb-4">
+      <div className="mb-16 border-l-2 border-tag-ai/60 pl-6 md:pl-8">
+        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-4">
           How I learn
         </p>
         <p className="text-base text-foreground leading-relaxed max-w-2xl">
@@ -76,7 +81,7 @@ const AboutPage = () => {
 
       {/* Interests */}
       <div className="mb-16">
-        <p className="font-mono text-sm uppercase tracking-widest text-muted-foreground mb-6">
+        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-6">
           Outside the terminal
         </p>
         <div className="flex flex-wrap gap-3">
@@ -99,7 +104,7 @@ const AboutPage = () => {
 
       {/* Bucket list */}
       <div className="mb-16">
-        <p className="font-mono text-sm uppercase tracking-widest text-muted-foreground mb-6">
+        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-6">
           Bucket list
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
@@ -135,9 +140,9 @@ const AboutPage = () => {
       </div>
 
       {/* Education + Currently looking for */}
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-        <div className="rounded-xl border border-border bg-surface p-6 space-y-4">
-          <h2 className="font-mono text-sm uppercase tracking-widest text-muted-foreground">
+      <div className="grid grid-cols-1 gap-10 border-t border-border pt-10 md:grid-cols-2">
+        <div className="space-y-4">
+          <h2 className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
             Education
           </h2>
           <div>
@@ -174,8 +179,8 @@ const AboutPage = () => {
           </div>
         </div>
 
-        <div className="rounded-xl border border-border bg-surface p-6 space-y-3">
-          <h2 className="font-mono text-sm uppercase tracking-widest text-muted-foreground">
+        <div className="space-y-3">
+          <h2 className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
             Currently looking for
           </h2>
           <p className="text-sm text-muted-foreground">

--- a/src/modules/home/ui/ContactCTA.tsx
+++ b/src/modules/home/ui/ContactCTA.tsx
@@ -1,14 +1,18 @@
 import { ArrowRight } from "lucide-react";
 import { LuLinkedin, LuGithub } from "react-icons/lu";
 import { RiTwitterXLine } from "react-icons/ri";
+import PebbleField from "@/modules/journey/components/PebbleField";
 
 const ContactCTA = () => {
   return (
     <section className="relative mx-auto flex min-h-[80vh] w-full max-w-7xl flex-col justify-center px-4 py-24 sm:px-6 lg:px-8">
-      <p className="mb-10 text-center font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+      {/* Pebble finale - the system comes to rest, but still reacts to you */}
+      <PebbleField />
+
+      <p className="relative z-10 mb-10 text-center font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
         The next chapter
       </p>
-      <div>
+      <div className="relative z-10">
         <div className="mx-auto max-w-2xl space-y-8 text-center">
           {/* Status */}
           <div className="inline-flex items-center gap-2 rounded-md border border-tag-initiative/30 bg-tag-initiative/10 px-3 py-1.5">

--- a/src/modules/home/ui/ContactCTA.tsx
+++ b/src/modules/home/ui/ContactCTA.tsx
@@ -5,14 +5,15 @@ import { SOCIALS } from "@/components/Footer";
 
 const ContactCTA = () => {
   return (
-    <section className="relative mx-auto flex min-h-[80vh] w-full max-w-7xl flex-col justify-center px-4 py-24 sm:px-6 lg:px-8">
-      {/* Pebble finale - the system comes to rest, but still reacts to you */}
+    <section className="relative flex min-h-[80vh] w-full flex-col justify-center py-16">
+      {/* Pebble finale - full viewport width, the system comes to rest
+          but still reacts to you */}
       <PebbleField />
 
-      <p className="relative z-10 mb-10 text-center font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
-        The next chapter
-      </p>
-      <div className="relative z-10">
+      <div className="relative z-10 mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+        <p className="mb-10 text-center font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+          The next chapter
+        </p>
         <div className="mx-auto max-w-2xl space-y-8 text-center">
           {/* Status */}
           <div className="inline-flex items-center gap-2 rounded-md border border-tag-initiative/30 bg-tag-initiative/10 px-3 py-1.5">
@@ -39,7 +40,7 @@ const ContactCTA = () => {
           </div>
 
           {/* CTA */}
-          <div className="flex items-center justify-center gap-6 border-t border-border pt-8">
+          <div className="flex items-center justify-center gap-6">
             <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
               <a
                 href="mailto:mohdabdulaziz2023@gmail.com"

--- a/src/modules/home/ui/ContactCTA.tsx
+++ b/src/modules/home/ui/ContactCTA.tsx
@@ -1,7 +1,7 @@
 import { ArrowRight } from "lucide-react";
-import { LuLinkedin, LuGithub } from "react-icons/lu";
-import { RiTwitterXLine } from "react-icons/ri";
+import { LuLinkedin } from "react-icons/lu";
 import PebbleField from "@/modules/journey/components/PebbleField";
+import { SOCIALS } from "@/components/Footer";
 
 const ContactCTA = () => {
   return (
@@ -58,6 +58,30 @@ const ContactCTA = () => {
                 LinkedIn
               </a>
             </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Finale footer - the regular footer's contents live here on the
+          homepage, resting on the pebble floor */}
+      <div className="absolute inset-x-0 bottom-0 z-10 px-4 pb-6 sm:px-6 lg:px-8">
+        <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 border-t border-border pt-6 sm:flex-row">
+          <p className="font-mono text-xs text-muted-foreground">
+            © {new Date().getFullYear()} Abdul Aziz Mohammed
+          </p>
+          <div className="flex gap-2">
+            {SOCIALS.map(({ label, href, Icon }) => (
+              <a
+                key={label}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={label}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <Icon className="h-4 w-4" />
+              </a>
+            ))}
           </div>
         </div>
       </div>

--- a/src/modules/home/ui/SideProjects.tsx
+++ b/src/modules/home/ui/SideProjects.tsx
@@ -1,6 +1,19 @@
-import { ArrowUpRight } from "lucide-react";
+"use client";
+
+import { useRef } from "react";
+import Link from "next/link";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
 import { LuGithub } from "react-icons/lu";
+import { useGSAP } from "@gsap/react";
+import { gsap } from "@/modules/journey/lib/scroll";
+import MaskReveal from "@/modules/journey/components/MaskReveal";
 import { Tag, type TagVariant } from "@/components/ui/tag";
+
+/**
+ * Epilogue - side projects (Master_PRP §10.5, Phase 11).
+ * A proper chapter: kicker + MaskReveal heading, a large featured card
+ * for AI Triage System, the rest in a staggered grid, CTA to /projects.
+ */
 
 interface SideProject {
   tag: string;
@@ -12,23 +25,25 @@ interface SideProject {
   live?: string;
 }
 
+const FEATURED: SideProject = {
+  tag: "AGENTIC AI",
+  variant: "ai",
+  name: "AI Triage System",
+  description:
+    "AI agent that triages inbound return/refund emails into tickets, cites store policy, and safely auto-executes low-risk Stripe refunds - escalating edge cases to CSRs. Fail-safe by design: the agent only acts where the blast radius is small.",
+  stack: ["Next.js", "Inngest", "Stripe", "Neon", "Drizzle", "Clerk"],
+  github: "https://github.com/abd-az1z/ai-triage-system",
+  live: "https://ai-triage-system-ashen.vercel.app",
+};
+
 const PROJECTS: SideProject[] = [
-  {
-    tag: "AGENTIC AI",
-    variant: "ai",
-    name: "AI Triage System",
-    description:
-      "AI agent that triages inbound return/refund emails into tickets, cites store policy, and safely auto-executes low-risk Stripe refunds - escalating edge cases to CSRs.",
-    stack: ["Next.js", "Inngest", "Stripe", "Neon", "Drizzle", "Clerk"],
-    github: "https://github.com/abd-az1z/ai-triage-system",
-  },
   {
     tag: "AI TOOLING",
     variant: "ai",
     name: "PromptShrink",
     description:
       "Reduce token usage while preserving meaning. Compresses prompts intelligently to cut API costs without degrading output quality.",
-    stack: ["Next.js", "OpenAI", "Anthropic SDK", "TypeScript"],
+    stack: ["Next.js", "OpenAI", "Anthropic SDK"],
     github: "https://github.com/abd-az1z/promptshrink",
     live: "https://promptshrink.vercel.app",
   },
@@ -47,8 +62,8 @@ const PROJECTS: SideProject[] = [
     variant: "neutral",
     name: "SaaScribe AI",
     description:
-      "Transform PDFs into intelligent conversations - upload documents, embed them, and chat with your content using AI-powered understanding.",
-    stack: ["Next.js", "LangChain", "Pinecone", "Clerk", "Neon", "Stripe"],
+      "Transform PDFs into intelligent conversations - upload documents, embed them, and chat with your content.",
+    stack: ["Next.js", "LangChain", "Pinecone", "Neon"],
     github: "https://github.com/abd-az1z/SaaScribe.ai",
   },
   {
@@ -57,7 +72,7 @@ const PROJECTS: SideProject[] = [
     name: "CallSage",
     description:
       "AI-powered video conferencing with custom AI agents - real-time video, auth, async agent jobs, and database built end-to-end.",
-    stack: ["Next.js", "Stream", "OpenAI", "BetterAuth", "Inngest", "Neon", "Drizzle"],
+    stack: ["Next.js", "Stream", "OpenAI", "Inngest"],
     github: "https://github.com/abd-az1z/callsage.com",
     live: "https://callsage-com-8m9w.vercel.app",
   },
@@ -67,62 +82,145 @@ const PROJECTS: SideProject[] = [
     name: "AICortex",
     description:
       "Reduce LLM spend by 20–40% without degrading output quality - multi-provider model routing across Anthropic, OpenAI, and Mistral.",
-    stack: ["Next.js", "Anthropic SDK", "OpenAI", "Mistral", "Stripe"],
+    stack: ["Next.js", "Anthropic SDK", "Mistral"],
     github: "https://github.com/abd-az1z/aicortex",
     live: "https://aicortex.vercel.app",
   },
 ];
 
-const SideProjects = () => {
-  return (
-    <section className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 lg:px-8">
-      <h2 className="mb-8 font-mono text-sm uppercase tracking-widest text-muted-foreground">
-        Side Projects
-      </h2>
+const CardLinks = ({ github, live }: { github: string; live?: string }) => (
+  <div className="flex items-center gap-4 border-t border-border pt-4">
+    <a
+      href={github}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <LuGithub className="h-4 w-4" />
+      GitHub
+    </a>
+    {live && (
+      <a
+        href={live}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowUpRight className="h-4 w-4" />
+        Live
+      </a>
+    )}
+  </div>
+);
 
+const SideProjects = () => {
+  const root = useRef<HTMLElement>(null);
+
+  useGSAP(
+    () => {
+      const mm = gsap.matchMedia();
+      mm.add("(prefers-reduced-motion: no-preference)", () => {
+        gsap.from("[data-epilogue-card]", {
+          opacity: 0,
+          y: 30,
+          duration: 0.7,
+          stagger: 0.1,
+          ease: "power3.out",
+          scrollTrigger: {
+            trigger: root.current,
+            start: "top 65%",
+            once: true,
+          },
+        });
+      });
+      return () => mm.revert();
+    },
+    { scope: root }
+  );
+
+  return (
+    <section
+      ref={root}
+      id="scene-projects"
+      className="mx-auto w-full max-w-7xl px-4 py-28 sm:px-6 lg:px-8"
+    >
+      <p className="mb-6 font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+        Epilogue · Off the clock
+      </p>
+      <MaskReveal className="mb-12">
+        <h2 className="max-w-2xl text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl">
+          What I build{" "}
+          <span className="text-muted-foreground">when nobody&apos;s asking.</span>
+        </h2>
+      </MaskReveal>
+
+      {/* Featured: AI Triage System */}
+      <div
+        data-epilogue-card
+        className="relative mb-6 overflow-hidden rounded-xl border border-border bg-surface p-8 transition-colors hover:border-white/15 md:p-10"
+      >
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_80%_at_85%_20%,rgba(139,92,246,0.08),transparent_60%)]"
+        />
+        <div className="relative flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-2xl space-y-4">
+            <div className="flex items-center gap-3">
+              <Tag variant={FEATURED.variant}>{FEATURED.tag}</Tag>
+              <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                Featured
+              </span>
+            </div>
+            <h3 className="text-2xl font-semibold text-foreground md:text-3xl">
+              {FEATURED.name}
+            </h3>
+            <p className="text-base leading-relaxed text-muted-foreground">
+              {FEATURED.description}
+            </p>
+            <p className="font-mono text-xs text-muted-foreground">
+              {FEATURED.stack.join(" · ")}
+            </p>
+          </div>
+          <div className="shrink-0">
+            <CardLinks github={FEATURED.github} live={FEATURED.live} />
+          </div>
+        </div>
+      </div>
+
+      {/* The rest */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {PROJECTS.map(({ tag, variant, name, description, stack, github, live }) => (
           <div
             key={name}
+            data-epilogue-card
             className="flex flex-col gap-4 rounded-xl border border-border bg-surface p-6 transition-colors hover:border-white/15"
           >
             <div className="flex items-start justify-between gap-4">
               <h3 className="text-lg font-semibold text-foreground">{name}</h3>
               <Tag variant={variant}>{tag}</Tag>
             </div>
-
             <p className="flex-1 text-sm leading-relaxed text-muted-foreground">
               {description}
             </p>
-
-            <p className="font-mono text-xs text-muted-foreground">
-              {stack.join(" · ")}
-            </p>
-
-            <div className="flex items-center gap-4 border-t border-border pt-4">
-              <a
-                href={github}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <LuGithub className="h-4 w-4" />
-                GitHub
-              </a>
-              {live && (
-                <a
-                  href={live}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <ArrowUpRight className="h-4 w-4" />
-                  Live
-                </a>
-              )}
-            </div>
+            <p className="font-mono text-xs text-muted-foreground">{stack.join(" · ")}</p>
+            <CardLinks github={github} live={live} />
           </div>
         ))}
+
+        {/* CTA card to the full list */}
+        <Link
+          href="/projects"
+          data-epilogue-card
+          className="group flex min-h-[180px] flex-col items-start justify-between rounded-xl border border-dashed border-border p-6 transition-colors hover:border-white/25"
+        >
+          <p className="text-sm text-muted-foreground">
+            Filters, more builds, and everything in between.
+          </p>
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+            All projects
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+          </span>
+        </Link>
       </div>
     </section>
   );

--- a/src/modules/journey/JourneyView.tsx
+++ b/src/modules/journey/JourneyView.tsx
@@ -39,12 +39,10 @@ const JourneyView = () => {
         <ShipScene />
         <NowScene />
 
-        {/* 8 - side projects (stats live inside the scenes themselves) */}
-        <FadeIn>
-          <SideProjects />
-        </FadeIn>
+        {/* 8 - epilogue: side projects (self-choreographed) */}
+        <SideProjects />
 
-        {/* 10 - contact (id anchors the companion node's final waypoint) */}
+        {/* 9 - contact (id anchors the companion node's final waypoint) */}
         <div id="scene-contact">
           <FadeIn delay={0.05}>
             <ContactCTA />

--- a/src/modules/journey/components/PebbleField.tsx
+++ b/src/modules/journey/components/PebbleField.tsx
@@ -17,7 +17,7 @@ import { prefersReducedMotion } from "../lib/scroll";
  * off-screen.
  */
 
-const COUNT = 56;
+const COUNT = 220;
 const GRAVITY = 0.25;
 const AIR = 0.995;
 const BOUNCE = 0.55;
@@ -25,15 +25,32 @@ const FLOOR_FRICTION = 0.92;
 const CURSOR_RADIUS = 90;
 const CURSOR_KICK = 2.4;
 
-// Journey palette: mostly quiet, a few tag-colored
+// Palette sampled from the six scene films: security's cyan streams and
+// red anomaly, the monolith's teal circuitry, RAG's violet point cloud,
+// the signal's emerald route, ship's deep-blue grid, now's amber core.
 const COLORS = [
-  "rgba(255,255,255,0.28)",
-  "rgba(255,255,255,0.18)",
-  "rgba(59,130,246,0.55)",
-  "rgba(34,211,238,0.5)",
-  "rgba(139,92,246,0.5)",
-  "rgba(16,185,129,0.5)",
-  "rgba(245,158,11,0.45)",
+  // security - cyan data streams (dominant hue of the film)
+  "rgba(34,211,238,0.55)",
+  "rgba(103,232,249,0.4)",
+  // security - the red anomaly (rare)
+  "rgba(239,68,68,0.6)",
+  // monolith - teal circuitry
+  "rgba(45,212,191,0.5)",
+  "rgba(20,184,166,0.4)",
+  // rag - violet point cloud
+  "rgba(139,92,246,0.55)",
+  "rgba(167,139,250,0.4)",
+  // signal - emerald route
+  "rgba(16,185,129,0.55)",
+  "rgba(52,211,153,0.4)",
+  // ship - deep blue grid
+  "rgba(59,130,246,0.5)",
+  "rgba(96,165,250,0.35)",
+  // now - amber core (rare, like the film)
+  "rgba(245,158,11,0.55)",
+  // quiet connective tissue
+  "rgba(255,255,255,0.2)",
+  "rgba(255,255,255,0.12)",
 ];
 
 interface Pebble {
@@ -84,10 +101,10 @@ const PebbleField = () => {
 
     // Seed: scattered along the floor with a little variance
     for (let i = 0; i < COUNT; i++) {
-      const r = 3 + Math.random() * 7;
+      const r = 2.5 + Math.random() * 5.5;
       pebbles.push({
         x: Math.random() * W,
-        y: H - r - Math.random() * 40,
+        y: H - r - Math.random() * 70,
         vx: 0,
         vy: 0,
         r,

--- a/src/modules/journey/components/PebbleField.tsx
+++ b/src/modules/journey/components/PebbleField.tsx
@@ -17,6 +17,8 @@ import { prefersReducedMotion } from "../lib/scroll";
  * off-screen.
  */
 
+// Base count; actual count scales with viewport width so big screens
+// stay as dense as laptops (see seeding below).
 const COUNT = 220;
 const GRAVITY = 0.25;
 const AIR = 0.995;
@@ -99,9 +101,12 @@ const PebbleField = () => {
     };
     resize();
 
-    // Seed: scattered along the floor with a little variance
-    for (let i = 0; i < COUNT; i++) {
-      const r = 2.5 + Math.random() * 5.5;
+    // Seed: scattered along the floor with a little variance.
+    // Density-scaled: ~one pebble per 6px of width, clamped so laptops
+    // and ultrawides both feel full without overloading the sim.
+    const count = Math.max(COUNT, Math.min(Math.round(W / 6), 380));
+    for (let i = 0; i < count; i++) {
+      const r = 4 + Math.random() * 8;
       pebbles.push({
         x: Math.random() * W,
         y: H - r - Math.random() * 70,

--- a/src/modules/journey/components/PebbleField.tsx
+++ b/src/modules/journey/components/PebbleField.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { prefersReducedMotion } from "../lib/scroll";
+
+/**
+ * Pebble field finale (Master_PRP §10.5, Phase 15).
+ *
+ * A bed of node-pebbles resting on the contact section's floor. The
+ * cursor kicks them around - they bounce off walls, floor, and each
+ * other with springy physics, then settle back under gravity.
+ * Bookends the constellation hero: the site opens and closes with a
+ * system reacting to your touch.
+ *
+ * Canvas 2D, zero dependencies. Fine-pointer desktops only; never
+ * rendered on mobile or under prefers-reduced-motion. Pauses when
+ * off-screen.
+ */
+
+const COUNT = 56;
+const GRAVITY = 0.25;
+const AIR = 0.995;
+const BOUNCE = 0.55;
+const FLOOR_FRICTION = 0.92;
+const CURSOR_RADIUS = 90;
+const CURSOR_KICK = 2.4;
+
+// Journey palette: mostly quiet, a few tag-colored
+const COLORS = [
+  "rgba(255,255,255,0.28)",
+  "rgba(255,255,255,0.18)",
+  "rgba(59,130,246,0.55)",
+  "rgba(34,211,238,0.5)",
+  "rgba(139,92,246,0.5)",
+  "rgba(16,185,129,0.5)",
+  "rgba(245,158,11,0.45)",
+];
+
+interface Pebble {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  color: string;
+}
+
+const PebbleField = () => {
+  const [enabled, setEnabled] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const desktop = window.matchMedia("(pointer: fine) and (min-width: 768px)").matches;
+    setEnabled(desktop && !prefersReducedMotion());
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const canvas = canvasRef.current;
+    const parent = canvas?.parentElement;
+    if (!canvas || !parent) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let W = 0;
+    let H = 0;
+    let dpr = 1;
+    const pebbles: Pebble[] = [];
+    const cursor = { x: -9999, y: -9999, vx: 0, vy: 0, px: -9999, py: -9999 };
+    let raf = 0;
+    let running = false;
+
+    const resize = () => {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      W = parent.clientWidth;
+      H = parent.clientHeight;
+      canvas.width = W * dpr;
+      canvas.height = H * dpr;
+      canvas.style.width = `${W}px`;
+      canvas.style.height = `${H}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+
+    // Seed: scattered along the floor with a little variance
+    for (let i = 0; i < COUNT; i++) {
+      const r = 3 + Math.random() * 7;
+      pebbles.push({
+        x: Math.random() * W,
+        y: H - r - Math.random() * 40,
+        vx: 0,
+        vy: 0,
+        r,
+        color: COLORS[Math.floor(Math.random() * COLORS.length)],
+      });
+    }
+
+    const step = () => {
+      // Cursor velocity (how hard the visitor is "kicking")
+      cursor.vx = cursor.x - cursor.px;
+      cursor.vy = cursor.y - cursor.py;
+      cursor.px = cursor.x;
+      cursor.py = cursor.y;
+
+      for (const p of pebbles) {
+        // Cursor kick: push away, harder when the cursor moves fast
+        const dx = p.x - cursor.x;
+        const dy = p.y - cursor.y;
+        const d = Math.hypot(dx, dy);
+        if (d < CURSOR_RADIUS && d > 0.001) {
+          const force = ((CURSOR_RADIUS - d) / CURSOR_RADIUS) * CURSOR_KICK;
+          const speed = Math.min(Math.hypot(cursor.vx, cursor.vy), 40) * 0.06 + 0.4;
+          p.vx += (dx / d) * force * speed;
+          p.vy += (dy / d) * force * speed - force * 0.3; // slight pop upward
+        }
+
+        p.vy += GRAVITY;
+        p.vx *= AIR;
+        p.vy *= AIR;
+        p.x += p.vx;
+        p.y += p.vy;
+
+        // Walls + floor + ceiling
+        if (p.x < p.r) { p.x = p.r; p.vx *= -BOUNCE; }
+        if (p.x > W - p.r) { p.x = W - p.r; p.vx *= -BOUNCE; }
+        if (p.y > H - p.r) { p.y = H - p.r; p.vy *= -BOUNCE; p.vx *= FLOOR_FRICTION; }
+        if (p.y < p.r) { p.y = p.r; p.vy *= -BOUNCE; }
+      }
+
+      // Pebble-pebble collisions (positional separation + impulse swap)
+      for (let i = 0; i < pebbles.length; i++) {
+        for (let j = i + 1; j < pebbles.length; j++) {
+          const a = pebbles[i];
+          const b = pebbles[j];
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const d = Math.hypot(dx, dy);
+          const min = a.r + b.r;
+          if (d < min && d > 0.001) {
+            const nx = dx / d;
+            const ny = dy / d;
+            const overlap = (min - d) / 2;
+            a.x -= nx * overlap;
+            a.y -= ny * overlap;
+            b.x += nx * overlap;
+            b.y += ny * overlap;
+            const rel = (a.vx - b.vx) * nx + (a.vy - b.vy) * ny;
+            if (rel > 0) {
+              const imp = rel * 0.5 * BOUNCE;
+              a.vx -= nx * imp;
+              a.vy -= ny * imp;
+              b.vx += nx * imp;
+              b.vy += ny * imp;
+            }
+          }
+        }
+      }
+
+      ctx.clearRect(0, 0, W, H);
+      for (const p of pebbles) {
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fillStyle = p.color;
+        ctx.fill();
+      }
+
+      raf = requestAnimationFrame(step);
+    };
+
+    const start = () => {
+      if (!running) {
+        running = true;
+        raf = requestAnimationFrame(step);
+      }
+    };
+    const stop = () => {
+      running = false;
+      cancelAnimationFrame(raf);
+    };
+
+    // Only simulate while visible
+    const io = new IntersectionObserver(
+      ([entry]) => (entry.isIntersecting ? start() : stop()),
+      { rootMargin: "50px" }
+    );
+    io.observe(parent);
+
+    const onMove = (e: PointerEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      cursor.x = e.clientX - rect.left;
+      cursor.y = e.clientY - rect.top;
+    };
+    const onLeave = () => {
+      cursor.x = -9999;
+      cursor.y = -9999;
+    };
+    parent.addEventListener("pointermove", onMove);
+    parent.addEventListener("pointerleave", onLeave);
+    window.addEventListener("resize", resize);
+
+    return () => {
+      stop();
+      io.disconnect();
+      parent.removeEventListener("pointermove", onMove);
+      parent.removeEventListener("pointerleave", onLeave);
+      window.removeEventListener("resize", resize);
+    };
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="pointer-events-none absolute inset-0"
+    />
+  );
+};
+
+export default PebbleField;

--- a/src/modules/projects/ui/ProjectsPage.tsx
+++ b/src/modules/projects/ui/ProjectsPage.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { ArrowUpRight } from "lucide-react";
 import { LuGithub } from "react-icons/lu";
+import { useGSAP } from "@gsap/react";
+import { gsap } from "@/modules/journey/lib/scroll";
+import MaskReveal from "@/modules/journey/components/MaskReveal";
 import { Tag, type TagVariant } from "@/components/ui/tag";
 import { PROJECTS, type Project } from "@/data/projects";
 
@@ -40,7 +43,10 @@ function ProjectCard({ project }: { project: Project }) {
   const { label, variant } = TAG_MAP[project.id] ?? { label: "PROJECT", variant: "neutral" as TagVariant };
 
   return (
-    <div className="flex flex-col gap-4 rounded-xl border border-border bg-surface p-6 transition-colors hover:border-white/15">
+    <div
+      data-project-card
+      className="flex flex-col gap-4 rounded-xl border border-border bg-surface p-6 transition-colors hover:border-white/15"
+    >
       <div className="flex items-start justify-between gap-4">
         <h3 className="text-lg font-semibold text-foreground">{project.title}</h3>
         <Tag variant={variant}>{label}</Tag>
@@ -76,19 +82,41 @@ function ProjectCard({ project }: { project: Project }) {
 }
 
 export default function ProjectsPage() {
+  const root = useRef<HTMLDivElement>(null);
   const [active, setActive] = useState<Filter>("all");
 
   const filtered = active === "all"
     ? PROJECTS
     : PROJECTS.filter((p) => PROJECT_FILTERS[p.id]?.includes(active));
 
+  useGSAP(
+    () => {
+      const mm = gsap.matchMedia();
+      mm.add("(prefers-reduced-motion: no-preference)", () => {
+        gsap.from("[data-project-card]", {
+          opacity: 0,
+          y: 24,
+          duration: 0.6,
+          stagger: 0.07,
+          ease: "power3.out",
+        });
+      });
+      return () => mm.revert();
+    },
+    { scope: root }
+  );
+
   return (
-    <div className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
+    <div ref={root} className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
       <div className="mb-12 space-y-3">
-        <p className="font-mono text-sm uppercase tracking-widest text-muted-foreground">Projects</p>
-        <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-          Things I&apos;ve built
-        </h1>
+        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+          Projects · The lab
+        </p>
+        <MaskReveal>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+            Things I&apos;ve built
+          </h1>
+        </MaskReveal>
         <p className="max-w-xl text-base text-muted-foreground">
           Side projects and production work - AI agents, SaaS tools, and infrastructure built end-to-end.
         </p>
@@ -97,7 +125,7 @@ export default function ProjectsPage() {
       <div className="mb-10 flex flex-wrap gap-2">
         {FILTERS.map(({ id, label }) => (
           <button key={id} type="button" onClick={() => setActive(id)}
-            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+            className={`rounded-full px-4 py-1.5 font-mono text-xs uppercase tracking-wider transition-colors ${
               active === id
                 ? "bg-white text-black"
                 : "border border-border text-muted-foreground hover:border-white/20 hover:text-foreground"

--- a/src/modules/work/ui/WorkPage.tsx
+++ b/src/modules/work/ui/WorkPage.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import { useRef } from "react";
+import { useGSAP } from "@gsap/react";
+import { gsap } from "@/modules/journey/lib/scroll";
+import MaskReveal from "@/modules/journey/components/MaskReveal";
 import { Tag, type TagVariant } from "@/components/ui/tag";
 
 interface TimelineEvent {
@@ -7,6 +13,16 @@ interface TimelineEvent {
   tag?: string;
   variant?: TagVariant;
 }
+
+// Timeline node classes per tag variant (matches the tag color system)
+const NODE_CLASS: Record<string, string> = {
+  security: "bg-tag-security shadow-[0_0_8px_#ef4444]",
+  architecture: "bg-tag-architecture shadow-[0_0_8px_#3b82f6]",
+  ai: "bg-tag-ai shadow-[0_0_8px_#8b5cf6]",
+  migration: "bg-tag-migration shadow-[0_0_8px_#f59e0b]",
+  initiative: "bg-tag-initiative shadow-[0_0_8px_#10b981]",
+  neutral: "bg-white/50",
+};
 
 const AGENTNOMICS: TimelineEvent[] = [
   {
@@ -87,11 +103,19 @@ function Timeline({ events }: { events: TimelineEvent[] }) {
       <div className="absolute left-0 top-0 h-full w-px bg-border md:left-[140px]" />
       <div className="space-y-0">
         {events.map(({ date, title, detail, tag, variant }, i) => (
-          <div key={i} className="relative flex flex-col gap-2 pb-10 pl-6 md:flex-row md:gap-10 md:pl-0">
+          <div
+            key={i}
+            data-timeline-item
+            className="relative flex flex-col gap-2 pb-10 pl-6 md:flex-row md:gap-10 md:pl-0"
+          >
             <div className="shrink-0 md:w-[140px] md:text-right">
               <span className="font-mono text-xs text-muted-foreground">{date}</span>
             </div>
-            <div className="absolute left-[-4px] top-[2px] h-2 w-2 rounded-full border border-border bg-background md:left-[136px]" />
+            <div
+              className={`absolute left-[-4px] top-[2px] h-2 w-2 rounded-full md:left-[136px] ${
+                variant ? NODE_CLASS[variant] : "bg-white/30"
+              }`}
+            />
             <div className="flex-1 space-y-2 md:pl-10">
               <div className="flex flex-wrap items-center gap-3">
                 <h3 className="text-sm font-semibold text-foreground">{title}</h3>
@@ -107,16 +131,57 @@ function Timeline({ events }: { events: TimelineEvent[] }) {
 }
 
 export default function WorkPage() {
+  const root = useRef<HTMLDivElement>(null);
+
+  useGSAP(
+    () => {
+      const mm = gsap.matchMedia();
+      mm.add("(prefers-reduced-motion: no-preference)", () => {
+        gsap.from("[data-timeline-item]", {
+          opacity: 0,
+          x: -20,
+          duration: 0.6,
+          stagger: 0.08,
+          ease: "power3.out",
+          scrollTrigger: {
+            trigger: "[data-timeline-item]",
+            start: "top 75%",
+            once: true,
+          },
+        });
+        gsap.from("[data-accenture]", {
+          opacity: 0,
+          y: 24,
+          duration: 0.7,
+          ease: "power3.out",
+          scrollTrigger: {
+            trigger: "[data-accenture]",
+            start: "top 80%",
+            once: true,
+          },
+        });
+      });
+      return () => mm.revert();
+    },
+    { scope: root }
+  );
+
   return (
-    <div className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
+    <div ref={root} className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
       {/* Header */}
       <div className="mb-16 max-w-2xl space-y-4">
-        <p className="font-mono text-sm uppercase tracking-widest text-muted-foreground">Experience</p>
-        <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-          Where I&apos;ve worked
-        </h1>
+        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+          Experience · The deployment log
+        </p>
+        <MaskReveal>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+            Where I&apos;ve worked
+          </h1>
+        </MaskReveal>
         <p className="text-base text-muted-foreground md:text-lg">
-          8 months at Agentnomics.ai shipping production AI - security fixes, architecture migrations, RAG pipelines, vendor decisions, and client launches.
+          8 months at Agentnomics.ai shipping production AI - security fixes,
+          architecture migrations, RAG pipelines, vendor decisions, and client
+          launches.
         </p>
       </div>
 
@@ -124,18 +189,22 @@ export default function WorkPage() {
       <div className="mb-20">
         <div className="mb-10 flex flex-wrap items-baseline gap-4">
           <h2 className="text-xl font-bold text-foreground">Agentnomics.ai</h2>
-          <span className="font-mono text-sm text-muted-foreground">Software Engineer · Nov 2025 – Present · Remote</span>
+          <span className="font-mono text-sm text-muted-foreground">
+            Software Engineer · Nov 2025 – Present · Remote
+          </span>
         </div>
         <Timeline events={AGENTNOMICS} />
       </div>
 
       {/* Accenture */}
-      <div>
+      <div data-accenture>
         <div className="mb-8 flex flex-wrap items-baseline gap-4">
           <h2 className="text-xl font-bold text-foreground">Accenture</h2>
-          <span className="font-mono text-sm text-muted-foreground">Software Engineer, SAP S/4HANA · Feb 2021 – Sep 2022 · Hyderabad, India</span>
+          <span className="font-mono text-sm text-muted-foreground">
+            Software Engineer, SAP S/4HANA · Feb 2021 – Sep 2022 · Hyderabad, India
+          </span>
         </div>
-        <ul className="space-y-3 max-w-2xl">
+        <ul className="max-w-2xl space-y-3">
           {[
             "Built and supported enterprise software workflows across order management, pricing, delivery, invoicing, and production support.",
             "Translated business requirements into system configurations, process flows, test cases, and production-ready improvements.",


### PR DESCRIPTION
## Summary

Interior polish pass per Master_PRP §10.5 (Phases 10–15), user-reviewed on dev:

- **Chapter-aware nav** (homepage): scroll-progress line + live chapter label driven by IntersectionObserver
- **Epilogue projects scene**: featured AI Triage card, staggered grid, CTA to /projects
- **/work /projects /about** aligned to the journey language (tag-colored timeline nodes, MaskReveal, mono kickers, de-carded /about)
- **Pebble field finale**: full-bleed canvas physics floor in the film palette (220–380 pebbles, width-scaled), cursor kicks, gravity piles — bookends the constellation hero
- Footer folded into the homepage finale (other routes keep the regular footer)

## Test plan

- [x] Clean production build (all routes static)
- [x] Reviewed on dev by owner (desktop + mobile)
- [ ] Preview deploy scroll-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scroll-aware chapter labeling and a page progress indicator on the homepage.
  * Introduced a new animated background effect in the contact area.

* **UI/UX Improvements**
  * Updated Home, Work, Projects, About, and Side Projects sections with refreshed headings, layouts, and smoother reveal animations.
  * Added a featured project highlight and revised project section structure.
  * Improved footer visibility so it no longer appears on the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->