### PR TITLE
v2.2: interior destinations - Deployment Log, Lab, Human Layer

### DIFF
--- a/src/modules/about/ui/AboutPage.tsx
+++ b/src/modules/about/ui/AboutPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import {
   Dumbbell,
   Mountain,
@@ -14,7 +15,17 @@ import {
   Check,
   type LucideIcon,
 } from "lucide-react";
+import { useGSAP } from "@gsap/react";
+import { gsap } from "@/modules/journey/lib/scroll";
 import MaskReveal from "@/modules/journey/components/MaskReveal";
+import SceneVideo from "@/modules/journey/components/SceneVideo";
+
+/**
+ * /about - "The Human Layer" (Master_PRP §10.6, Phase 18).
+ * The person behind the system: the scene-now film (the amber
+ * heartbeat) backs the header, the bucket list reads as a dev-native
+ * coverage report that fills on scroll, and interest pills drift idly.
+ */
 
 const INTERESTS: { icon: LucideIcon; label: string }[] = [
   { icon: Dumbbell, label: "Workouts & Health" },
@@ -45,155 +56,234 @@ const BUCKET_LIST: { label: string; done: boolean }[] = [
   { label: "See the Northern Lights", done: true },
 ];
 
+const DONE = BUCKET_LIST.filter((b) => b.done).length;
+const TOTAL = BUCKET_LIST.length;
+const PCT = Math.round((DONE / TOTAL) * 100);
+
 const AboutPage = () => {
+  const root = useRef<HTMLDivElement>(null);
+
+  useGSAP(
+    () => {
+      const mm = gsap.matchMedia();
+      mm.add("(prefers-reduced-motion: no-preference)", () => {
+        // Interest pills drift idly, each on its own rhythm
+        gsap.utils.toArray<HTMLElement>("[data-pill]").forEach((pill, i) => {
+          gsap.to(pill, {
+            y: i % 2 ? 3 : -3,
+            duration: 2 + Math.random() * 1.5,
+            yoyo: true,
+            repeat: -1,
+            ease: "sine.inOut",
+            delay: Math.random(),
+          });
+        });
+
+        // Bucket-list coverage: the bar fills, done items check off
+        const tl = gsap.timeline({
+          scrollTrigger: { trigger: "[data-coverage]", start: "top 70%", once: true },
+        });
+        tl.fromTo(
+          "[data-coverage-bar]",
+          { scaleX: 0 },
+          { scaleX: 1, duration: 1.1, ease: "power3.inOut" }
+        ).from(
+          "[data-done-check]",
+          { scale: 0, duration: 0.4, stagger: 0.25, ease: "back.out(3)" },
+          "-=0.5"
+        );
+
+        gsap.from("[data-bucket-item]", {
+          opacity: 0,
+          y: 16,
+          duration: 0.5,
+          stagger: 0.04,
+          ease: "power3.out",
+          scrollTrigger: { trigger: "[data-coverage]", start: "top 70%", once: true },
+        });
+      });
+      return () => mm.revert();
+    },
+    { scope: root }
+  );
+
   return (
-    <div className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
-      {/* Header */}
-      <div className="mb-16 max-w-2xl space-y-4">
-        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
-          About · The person behind the PRs
-        </p>
-        <MaskReveal>
-          <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-            Beyond the code
-          </h1>
-        </MaskReveal>
-        <p className="text-base text-muted-foreground md:text-lg">
-          I&apos;m Abdul Aziz - a software engineer based in Seattle, WA. I
-          joined Agentnomics.ai in November 2025 and have been shipping
-          production AI systems ever since. But there&apos;s more to the story
-          than the commits.
-        </p>
-      </div>
-
-      {/* How I learn */}
-      <div className="mb-16 border-l-2 border-tag-ai/60 pl-6 md:pl-8">
-        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-4">
-          How I learn
-        </p>
-        <p className="text-base text-foreground leading-relaxed max-w-2xl">
-          I don&apos;t take courses to learn a skill. I pick the skill and build
-          something real with it. Every project in my portfolio started as a
-          question I needed to answer - not a tutorial I followed. That&apos;s
-          the only way I know how to retain anything.
-        </p>
-      </div>
-
-      {/* Interests */}
-      <div className="mb-16">
-        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-6">
-          Outside the terminal
-        </p>
-        <div className="flex flex-wrap gap-3">
-          {INTERESTS.map(({ icon: Icon, label }) => (
-            <span
-              key={label}
-              className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm text-foreground"
-            >
-              <Icon className="h-4 w-4 text-muted-foreground" />
-              <span>{label}</span>
-            </span>
-          ))}
-        </div>
-        <p className="mt-4 text-sm text-muted-foreground max-w-xl">
-          Particularly obsessed with space - Mars colonisation, the solar system, and
-          anything Elon or NASA puts up. I collect watches and gadgets the same
-          way I collect side projects: always one more.
-        </p>
-      </div>
-
-      {/* Bucket list */}
-      <div className="mb-16">
-        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-6">
-          Bucket list
-        </p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-          {BUCKET_LIST.map(({ label, done }) => (
-            <div
-              key={label}
-              className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3"
-            >
-              <span
-                className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border ${
-                  done
-                    ? "border-green-500 bg-green-500/10 text-green-400"
-                    : "border-white/20 text-transparent"
-                }`}
-              >
-                <Check className="h-3 w-3" strokeWidth={3} />
-              </span>
-              <span
-                className={`text-sm ${
-                  done
-                    ? "line-through text-muted-foreground"
-                    : "text-foreground"
-                }`}
-              >
-                {label}
-              </span>
-            </div>
-          ))}
-        </div>
-        <p className="mt-4 text-xs text-muted-foreground">
-          Always adding more. Always finding time.
-        </p>
-      </div>
-
-      {/* Education + Currently looking for */}
-      <div className="grid grid-cols-1 gap-10 border-t border-border pt-10 md:grid-cols-2">
-        <div className="space-y-4">
-          <h2 className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
-            Education
-          </h2>
-          <div>
-            <p className="text-sm font-semibold text-foreground">
-              MS, Information Technology Management (STEM)
+    <div ref={root} className="w-full">
+      {/* Film-backed header - the amber heartbeat, the human core */}
+      <div className="relative flex min-h-[45vh] w-full flex-col justify-end overflow-hidden">
+        <SceneVideo id="scene-now" />
+        <div className="relative z-10 mx-auto w-full max-w-7xl px-4 pb-14 pt-32 sm:px-6 lg:px-8">
+          <div className="max-w-2xl space-y-4">
+            <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+              About · The person behind the PRs
             </p>
-            <p className="text-sm text-muted-foreground">
-              <a
-                href="https://www.campbellsville.edu/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-foreground transition-colors underline underline-offset-4"
-              >
-                Campbellsville University
-              </a>
-              {" "}· May 2025
-            </p>
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">
-              BE, Electronics and Communication Engineering
-            </p>
-            <p className="text-sm text-muted-foreground">
-              <a
-                href="https://deccancollege.ac.in/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-foreground transition-colors underline underline-offset-4"
-              >
-                Deccan College
-              </a>
-              {" "}· July 2022
+            <MaskReveal>
+              <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+                Beyond the code
+              </h1>
+            </MaskReveal>
+            <p className="text-base text-muted-foreground md:text-lg">
+              I&apos;m Abdul Aziz - a software engineer based in Seattle, WA. I
+              joined Agentnomics.ai in November 2025 and have been shipping
+              production AI systems ever since. But there&apos;s more to the
+              story than the commits.
             </p>
           </div>
         </div>
+      </div>
 
-        <div className="space-y-3">
-          <h2 className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
-            Currently looking for
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Full-time software engineering roles at AI startups or mid-stage
-            SaaS companies - backend, full-stack, or AI infrastructure focus.
-            Remote or Seattle, WA.
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        {/* How I learn */}
+        <div className="mb-16 border-l-2 border-tag-ai/60 pl-6 md:pl-8">
+          <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-4">
+            How I learn
           </p>
-          <a
-            href="mailto:mohdabdulaziz2023@gmail.com"
-            className="inline-block text-sm font-medium text-foreground underline underline-offset-4 hover:text-muted-foreground transition-colors"
-          >
-            mohdabdulaziz2023@gmail.com
-          </a>
+          <p className="text-base text-foreground leading-relaxed max-w-2xl">
+            I don&apos;t take courses to learn a skill. I pick the skill and
+            build something real with it. Every project in my portfolio
+            started as a question I needed to answer - not a tutorial I
+            followed. That&apos;s the only way I know how to retain anything.
+          </p>
+        </div>
+
+        {/* Interests - drifting pills */}
+        <div className="mb-16">
+          <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground mb-6">
+            Outside the terminal
+          </p>
+          <div className="flex flex-wrap gap-3">
+            {INTERESTS.map(({ icon: Icon, label }) => (
+              <span
+                key={label}
+                data-pill
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm text-foreground transition-transform duration-200 hover:scale-105 hover:border-white/20"
+              >
+                <Icon className="h-4 w-4 text-muted-foreground" />
+                <span>{label}</span>
+              </span>
+            ))}
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground max-w-xl">
+            Particularly obsessed with space - Mars colonisation, the solar
+            system, and anything Elon or NASA puts up. I collect watches and
+            gadgets the same way I collect side projects: always one more.
+          </p>
+        </div>
+
+        {/* Bucket list - coverage report */}
+        <div data-coverage className="mb-16">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+            <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+              Bucket list
+            </p>
+            <p className="font-mono text-xs text-muted-foreground">
+              coverage: {DONE}/{TOTAL} · {PCT}% lived
+            </p>
+          </div>
+
+          {/* The coverage bar */}
+          <div className="mb-8 h-1 w-full overflow-hidden rounded-full bg-white/5">
+            <div className="h-full" style={{ width: `${PCT}%` }}>
+              <div
+                data-coverage-bar
+                className="h-full w-full origin-left rounded-full bg-gradient-to-r from-tag-initiative to-[#22d3ee]"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+            {BUCKET_LIST.map(({ label, done }) => (
+              <div
+                key={label}
+                data-bucket-item
+                className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3"
+              >
+                <span
+                  className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border ${
+                    done
+                      ? "border-green-500 bg-green-500/10 text-green-400"
+                      : "border-white/20 text-transparent"
+                  }`}
+                >
+                  {done ? (
+                    <span data-done-check className="flex">
+                      <Check className="h-3 w-3" strokeWidth={3} />
+                    </span>
+                  ) : (
+                    <Check className="h-3 w-3" strokeWidth={3} />
+                  )}
+                </span>
+                <span
+                  className={`text-sm ${
+                    done ? "line-through text-muted-foreground" : "text-foreground"
+                  }`}
+                >
+                  {label}
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            Always adding more. Always finding time.
+          </p>
+        </div>
+
+        {/* Education + Currently looking for */}
+        <div className="grid grid-cols-1 gap-10 border-t border-border pt-10 md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+              Education
+            </h2>
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                MS, Information Technology Management (STEM)
+              </p>
+              <p className="text-sm text-muted-foreground">
+                <a
+                  href="https://www.campbellsville.edu/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-foreground transition-colors underline underline-offset-4"
+                >
+                  Campbellsville University
+                </a>{" "}
+                · May 2025
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                BE, Electronics and Communication Engineering
+              </p>
+              <p className="text-sm text-muted-foreground">
+                <a
+                  href="https://deccancollege.ac.in/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-foreground transition-colors underline underline-offset-4"
+                >
+                  Deccan College
+                </a>{" "}
+                · July 2022
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <h2 className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+              Currently looking for
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Full-time software engineering roles at AI startups or mid-stage
+              SaaS companies - backend, full-stack, or AI infrastructure focus.
+              Remote or Seattle, WA.
+            </p>
+            <a
+              href="mailto:mohdabdulaziz2023@gmail.com"
+              className="inline-block text-sm font-medium text-foreground underline underline-offset-4 hover:text-muted-foreground transition-colors"
+            >
+              mohdabdulaziz2023@gmail.com
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/modules/projects/ui/ProjectsPage.tsx
+++ b/src/modules/projects/ui/ProjectsPage.tsx
@@ -1,13 +1,27 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { ArrowUpRight } from "lucide-react";
 import { LuGithub } from "react-icons/lu";
 import { useGSAP } from "@gsap/react";
-import { gsap } from "@/modules/journey/lib/scroll";
+import { Flip } from "gsap/Flip";
+import { gsap, prefersReducedMotion } from "@/modules/journey/lib/scroll";
 import MaskReveal from "@/modules/journey/components/MaskReveal";
+import SceneVideo from "@/modules/journey/components/SceneVideo";
 import { Tag, type TagVariant } from "@/components/ui/tag";
 import { PROJECTS, type Project } from "@/data/projects";
+
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(Flip);
+}
+
+/**
+ * /projects - "The Lab" (Master_PRP §10.6, Phase 17).
+ * A bench of running experiments: the scene-rag film backs the header,
+ * each card carries a tag-colored spotlight that tracks the cursor plus
+ * a subtle spring-back tilt, and filter changes FLIP cards to their new
+ * positions instead of snapping.
+ */
 
 type Filter = "all" | "ai" | "production" | "saas" | "infra";
 
@@ -39,21 +53,81 @@ const TAG_MAP: Record<string, { label: string; variant: TagVariant }> = {
   solvebot: { label: "AI / ACCESSIBLE", variant: "initiative" },
 };
 
+// Spotlight glow color per tag variant
+const GLOW: Record<TagVariant, string> = {
+  security: "rgba(239,68,68,0.10)",
+  architecture: "rgba(59,130,246,0.10)",
+  ai: "rgba(139,92,246,0.12)",
+  migration: "rgba(245,158,11,0.10)",
+  initiative: "rgba(16,185,129,0.10)",
+  neutral: "rgba(255,255,255,0.06)",
+};
+
+const MAX_TILT = 4; // degrees
+
 function ProjectCard({ project }: { project: Project }) {
-  const { label, variant } = TAG_MAP[project.id] ?? { label: "PROJECT", variant: "neutral" as TagVariant };
+  const { label, variant } = TAG_MAP[project.id] ?? {
+    label: "PROJECT",
+    variant: "neutral" as TagVariant,
+  };
+  const cardRef = useRef<HTMLDivElement>(null);
+  const spotRef = useRef<HTMLDivElement>(null);
+
+  const onMove = (e: React.PointerEvent) => {
+    const card = cardRef.current;
+    const spot = spotRef.current;
+    if (!card || !spot || prefersReducedMotion()) return;
+    const rect = card.getBoundingClientRect();
+    const px = (e.clientX - rect.left) / rect.width;
+    const py = (e.clientY - rect.top) / rect.height;
+
+    // Spotlight follows the cursor
+    spot.style.background = `radial-gradient(240px circle at ${px * 100}% ${py * 100}%, ${GLOW[variant]}, transparent 70%)`;
+    spot.style.opacity = "1";
+
+    // Subtle tilt toward the cursor
+    gsap.to(card, {
+      rotateY: (px - 0.5) * MAX_TILT * 2,
+      rotateX: (0.5 - py) * MAX_TILT * 2,
+      transformPerspective: 700,
+      duration: 0.4,
+      ease: "power2.out",
+    });
+  };
+
+  const onLeave = () => {
+    const card = cardRef.current;
+    const spot = spotRef.current;
+    if (spot) spot.style.opacity = "0";
+    if (card && !prefersReducedMotion()) {
+      gsap.to(card, { rotateX: 0, rotateY: 0, duration: 0.7, ease: "elastic.out(1, 0.5)" });
+    }
+  };
 
   return (
     <div
+      ref={cardRef}
       data-project-card
-      className="flex flex-col gap-4 rounded-xl border border-border bg-surface p-6 transition-colors hover:border-white/15"
+      onPointerMove={onMove}
+      onPointerLeave={onLeave}
+      className="relative flex flex-col gap-4 overflow-hidden rounded-xl border border-border bg-surface p-6 transition-colors hover:border-white/15 [transform-style:preserve-3d]"
     >
-      <div className="flex items-start justify-between gap-4">
+      {/* Cursor spotlight */}
+      <div
+        ref={spotRef}
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300"
+      />
+
+      <div className="relative flex items-start justify-between gap-4">
         <h3 className="text-lg font-semibold text-foreground">{project.title}</h3>
         <Tag variant={variant}>{label}</Tag>
       </div>
-      <p className="flex-1 text-sm leading-relaxed text-muted-foreground">{project.blurb}</p>
+      <p className="relative flex-1 text-sm leading-relaxed text-muted-foreground">
+        {project.blurb}
+      </p>
       {project.points && project.points.length > 0 && (
-        <ul className="space-y-1.5">
+        <ul className="relative space-y-1.5">
           {project.points.slice(0, 3).map((point) => (
             <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
               <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-muted-foreground" />
@@ -62,17 +136,27 @@ function ProjectCard({ project }: { project: Project }) {
           ))}
         </ul>
       )}
-      <p className="font-mono text-xs text-muted-foreground">{project.tags?.join(" · ")}</p>
-      <div className="flex items-center gap-4 border-t border-border pt-4">
+      <p className="relative font-mono text-xs text-muted-foreground">
+        {project.tags?.join(" · ")}
+      </p>
+      <div className="relative flex items-center gap-4 border-t border-border pt-4">
         {project.github && (
-          <a href={project.github} target="_blank" rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
+          <a
+            href={project.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
             <LuGithub className="h-4 w-4" /> GitHub
           </a>
         )}
         {project.link && project.link !== project.github && (
-          <a href={project.link} target="_blank" rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
+          <a
+            href={project.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
             <ArrowUpRight className="h-4 w-4" /> Live
           </a>
         )}
@@ -83,11 +167,34 @@ function ProjectCard({ project }: { project: Project }) {
 
 export default function ProjectsPage() {
   const root = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const flipState = useRef<ReturnType<typeof Flip.getState> | null>(null);
   const [active, setActive] = useState<Filter>("all");
 
-  const filtered = active === "all"
-    ? PROJECTS
-    : PROJECTS.filter((p) => PROJECT_FILTERS[p.id]?.includes(active));
+  const filtered =
+    active === "all" ? PROJECTS : PROJECTS.filter((p) => PROJECT_FILTERS[p.id]?.includes(active));
+
+  // Capture positions before the filter re-render...
+  const changeFilter = (next: Filter) => {
+    if (next === active) return;
+    if (gridRef.current && !prefersReducedMotion()) {
+      flipState.current = Flip.getState(gridRef.current.querySelectorAll("[data-project-card]"));
+    }
+    setActive(next);
+  };
+
+  // ...then FLIP surviving cards into their new spots, fade newcomers in
+  useLayoutEffect(() => {
+    if (!flipState.current) return;
+    Flip.from(flipState.current, {
+      duration: 0.5,
+      ease: "power3.inOut",
+      absolute: true,
+      onEnter: (els) => gsap.fromTo(els, { opacity: 0, scale: 0.94 }, { opacity: 1, scale: 1, duration: 0.4 }),
+      onLeave: (els) => gsap.to(els, { opacity: 0, scale: 0.94, duration: 0.25 }),
+    });
+    flipState.current = null;
+  }, [active]);
 
   useGSAP(
     () => {
@@ -107,43 +214,58 @@ export default function ProjectsPage() {
   );
 
   return (
-    <div ref={root} className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
-      <div className="mb-12 space-y-3">
-        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
-          Projects · The lab
-        </p>
-        <MaskReveal>
-          <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-            Things I&apos;ve built
-          </h1>
-        </MaskReveal>
-        <p className="max-w-xl text-base text-muted-foreground">
-          Side projects and production work - AI agents, SaaS tools, and infrastructure built end-to-end.
-        </p>
+    <div ref={root} className="w-full">
+      {/* Film-backed header - the lab's data cloud */}
+      <div className="relative flex min-h-[45vh] w-full flex-col justify-end overflow-hidden">
+        <SceneVideo id="scene-rag" />
+        <div className="relative z-10 mx-auto w-full max-w-7xl px-4 pb-14 pt-32 sm:px-6 lg:px-8">
+          <div className="max-w-2xl space-y-3">
+            <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+              Projects · The lab
+            </p>
+            <MaskReveal>
+              <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+                Things I&apos;ve built
+              </h1>
+            </MaskReveal>
+            <p className="max-w-xl text-base text-muted-foreground">
+              Side projects and production work - AI agents, SaaS tools, and
+              infrastructure built end-to-end.
+            </p>
+          </div>
+        </div>
       </div>
 
-      <div className="mb-10 flex flex-wrap gap-2">
-        {FILTERS.map(({ id, label }) => (
-          <button key={id} type="button" onClick={() => setActive(id)}
-            className={`rounded-full px-4 py-1.5 font-mono text-xs uppercase tracking-wider transition-colors ${
-              active === id
-                ? "bg-white text-black"
-                : "border border-border text-muted-foreground hover:border-white/20 hover:text-foreground"
-            }`}>
-            {label}
-          </button>
-        ))}
-      </div>
+      <div className="mx-auto w-full max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mb-10 flex flex-wrap gap-2">
+          {FILTERS.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => changeFilter(id)}
+              className={`rounded-full px-4 py-1.5 font-mono text-xs uppercase tracking-wider transition-colors ${
+                active === id
+                  ? "bg-white text-black"
+                  : "border border-border text-muted-foreground hover:border-white/20 hover:text-foreground"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {filtered.map((project) => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
+        <div ref={gridRef} className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
+        </div>
 
-      {filtered.length === 0 && (
-        <p className="py-20 text-center text-sm text-muted-foreground">No projects match this filter.</p>
-      )}
+        {filtered.length === 0 && (
+          <p className="py-20 text-center text-sm text-muted-foreground">
+            No projects match this filter.
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/modules/work/ui/WorkPage.tsx
+++ b/src/modules/work/ui/WorkPage.tsx
@@ -4,7 +4,15 @@ import { useRef } from "react";
 import { useGSAP } from "@gsap/react";
 import { gsap } from "@/modules/journey/lib/scroll";
 import MaskReveal from "@/modules/journey/components/MaskReveal";
+import SceneVideo from "@/modules/journey/components/SceneVideo";
 import { Tag, type TagVariant } from "@/components/ui/tag";
+
+/**
+ * /work - "The Deployment Log" (Master_PRP §10.6, Phase 16).
+ * Reading a production system's history, not a resume: the scene-ship
+ * film backs the header, the timeline rail draws itself downward with
+ * scroll, and each node ignites in its tag color as the line passes.
+ */
 
 interface TimelineEvent {
   date: string;
@@ -14,14 +22,14 @@ interface TimelineEvent {
   variant?: TagVariant;
 }
 
-// Timeline node classes per tag variant (matches the tag color system)
+// Ignited node classes per tag variant (matches the tag color system)
 const NODE_CLASS: Record<string, string> = {
-  security: "bg-tag-security shadow-[0_0_8px_#ef4444]",
-  architecture: "bg-tag-architecture shadow-[0_0_8px_#3b82f6]",
-  ai: "bg-tag-ai shadow-[0_0_8px_#8b5cf6]",
-  migration: "bg-tag-migration shadow-[0_0_8px_#f59e0b]",
-  initiative: "bg-tag-initiative shadow-[0_0_8px_#10b981]",
-  neutral: "bg-white/50",
+  security: "bg-tag-security shadow-[0_0_10px_#ef4444]",
+  architecture: "bg-tag-architecture shadow-[0_0_10px_#3b82f6]",
+  ai: "bg-tag-ai shadow-[0_0_10px_#8b5cf6]",
+  migration: "bg-tag-migration shadow-[0_0_10px_#f59e0b]",
+  initiative: "bg-tag-initiative shadow-[0_0_10px_#10b981]",
+  neutral: "bg-white/60 shadow-[0_0_8px_rgba(255,255,255,0.4)]",
 };
 
 const AGENTNOMICS: TimelineEvent[] = [
@@ -97,39 +105,6 @@ const AGENTNOMICS: TimelineEvent[] = [
   },
 ];
 
-function Timeline({ events }: { events: TimelineEvent[] }) {
-  return (
-    <div className="relative">
-      <div className="absolute left-0 top-0 h-full w-px bg-border md:left-[140px]" />
-      <div className="space-y-0">
-        {events.map(({ date, title, detail, tag, variant }, i) => (
-          <div
-            key={i}
-            data-timeline-item
-            className="relative flex flex-col gap-2 pb-10 pl-6 md:flex-row md:gap-10 md:pl-0"
-          >
-            <div className="shrink-0 md:w-[140px] md:text-right">
-              <span className="font-mono text-xs text-muted-foreground">{date}</span>
-            </div>
-            <div
-              className={`absolute left-[-4px] top-[2px] h-2 w-2 rounded-full md:left-[136px] ${
-                variant ? NODE_CLASS[variant] : "bg-white/30"
-              }`}
-            />
-            <div className="flex-1 space-y-2 md:pl-10">
-              <div className="flex flex-wrap items-center gap-3">
-                <h3 className="text-sm font-semibold text-foreground">{title}</h3>
-                {tag && variant && <Tag variant={variant}>{tag}</Tag>}
-              </div>
-              <p className="text-sm leading-relaxed text-muted-foreground">{detail}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export default function WorkPage() {
   const root = useRef<HTMLDivElement>(null);
 
@@ -137,28 +112,52 @@ export default function WorkPage() {
     () => {
       const mm = gsap.matchMedia();
       mm.add("(prefers-reduced-motion: no-preference)", () => {
-        gsap.from("[data-timeline-item]", {
-          opacity: 0,
-          x: -20,
-          duration: 0.6,
-          stagger: 0.08,
-          ease: "power3.out",
-          scrollTrigger: {
-            trigger: "[data-timeline-item]",
-            start: "top 75%",
-            once: true,
-          },
+        // The rail draws itself downward as you scroll through the log
+        gsap.fromTo(
+          "[data-rail]",
+          { scaleY: 0 },
+          {
+            scaleY: 1,
+            ease: "none",
+            scrollTrigger: {
+              trigger: "[data-timeline]",
+              start: "top 60%",
+              end: "bottom 60%",
+              scrub: 0.5,
+            },
+          }
+        );
+
+        // Each entry ignites as the rail reaches it
+        gsap.utils.toArray<HTMLElement>("[data-timeline-item]").forEach((item) => {
+          const node = item.querySelector("[data-node]");
+          const body = item.querySelector("[data-entry]");
+          const tl = gsap.timeline({
+            scrollTrigger: { trigger: item, start: "top 62%", once: true },
+          });
+          if (node) {
+            tl.fromTo(
+              node,
+              { opacity: 0.2, scale: 0.6 },
+              { opacity: 1, scale: 1, duration: 0.35, ease: "back.out(2.5)" }
+            );
+          }
+          if (body) {
+            tl.fromTo(
+              body,
+              { opacity: 0, x: -16 },
+              { opacity: 1, x: 0, duration: 0.5, ease: "power3.out" },
+              "-=0.15"
+            );
+          }
         });
+
         gsap.from("[data-accenture]", {
           opacity: 0,
           y: 24,
           duration: 0.7,
           ease: "power3.out",
-          scrollTrigger: {
-            trigger: "[data-accenture]",
-            start: "top 80%",
-            once: true,
-          },
+          scrollTrigger: { trigger: "[data-accenture]", start: "top 80%", once: true },
         });
       });
       return () => mm.revert();
@@ -167,55 +166,104 @@ export default function WorkPage() {
   );
 
   return (
-    <div ref={root} className="mx-auto w-full max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
-      {/* Header */}
-      <div className="mb-16 max-w-2xl space-y-4">
-        <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
-          Experience · The deployment log
-        </p>
-        <MaskReveal>
-          <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-            Where I&apos;ve worked
-          </h1>
-        </MaskReveal>
-        <p className="text-base text-muted-foreground md:text-lg">
-          8 months at Agentnomics.ai shipping production AI - security fixes,
-          architecture migrations, RAG pipelines, vendor decisions, and client
-          launches.
-        </p>
+    <div ref={root} className="w-full">
+      {/* Film-backed header - the deploy pipelines flowing */}
+      <div className="relative flex min-h-[45vh] w-full flex-col justify-end overflow-hidden">
+        <SceneVideo id="scene-ship" />
+        <div className="relative z-10 mx-auto w-full max-w-7xl px-4 pb-14 pt-32 sm:px-6 lg:px-8">
+          <div className="max-w-2xl space-y-4">
+            <p className="font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+              Experience · The deployment log
+            </p>
+            <MaskReveal>
+              <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+                Where I&apos;ve worked
+              </h1>
+            </MaskReveal>
+            <p className="text-base text-muted-foreground md:text-lg">
+              8 months at Agentnomics.ai shipping production AI - security
+              fixes, architecture migrations, RAG pipelines, vendor decisions,
+              and client launches.
+            </p>
+          </div>
+        </div>
       </div>
 
-      {/* Agentnomics */}
-      <div className="mb-20">
-        <div className="mb-10 flex flex-wrap items-baseline gap-4">
-          <h2 className="text-xl font-bold text-foreground">Agentnomics.ai</h2>
-          <span className="font-mono text-sm text-muted-foreground">
-            Software Engineer · Nov 2025 – Present · Remote
-          </span>
-        </div>
-        <Timeline events={AGENTNOMICS} />
-      </div>
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        {/* Agentnomics: sticky role block + drawing-rail log */}
+        <div className="mb-24 gap-12 md:grid md:grid-cols-[260px_1fr]">
+          <div className="mb-10 md:mb-0">
+            <div className="space-y-3 md:sticky md:top-28">
+              <h2 className="text-xl font-bold text-foreground">Agentnomics.ai</h2>
+              <p className="font-mono text-sm text-muted-foreground">Software Engineer</p>
+              <p className="font-mono text-xs text-muted-foreground">
+                Nov 2025 – Present · Remote
+              </p>
+              <p className="pt-2 text-sm leading-relaxed text-muted-foreground">
+                Production full-stack + AI platform work. 50+ PRs across
+                Flask, pgvector, Stripe, voice infra, and POS integrations.
+              </p>
+            </div>
+          </div>
 
-      {/* Accenture */}
-      <div data-accenture>
-        <div className="mb-8 flex flex-wrap items-baseline gap-4">
-          <h2 className="text-xl font-bold text-foreground">Accenture</h2>
-          <span className="font-mono text-sm text-muted-foreground">
-            Software Engineer, SAP S/4HANA · Feb 2021 – Sep 2022 · Hyderabad, India
-          </span>
+          <div data-timeline className="relative">
+            {/* The rail - draws downward with scroll */}
+            <div className="absolute left-[3px] top-1 h-full w-px bg-border" />
+            <div
+              data-rail
+              className="absolute left-[3px] top-1 h-full w-px origin-top bg-gradient-to-b from-[#22d3ee] to-[#3b82f6]"
+            />
+
+            <div className="space-y-12">
+              {AGENTNOMICS.map(({ date, title, detail, tag, variant }, i) => (
+                <div key={i} data-timeline-item className="relative pl-10">
+                  {/* Node - ignites in its tag color as the rail passes */}
+                  <div
+                    data-node
+                    className={`absolute left-0 top-[3px] h-[7px] w-[7px] rounded-full ${
+                      variant ? NODE_CLASS[variant] : "bg-white/40"
+                    }`}
+                  />
+                  <div data-entry className="space-y-2">
+                    <span className="font-mono text-xs text-muted-foreground">{date}</span>
+                    <div className="flex flex-wrap items-center gap-3">
+                      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+                      {tag && variant && <Tag variant={variant}>{tag}</Tag>}
+                    </div>
+                    <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+                      {detail}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
-        <ul className="max-w-2xl space-y-3">
-          {[
-            "Built and supported enterprise software workflows across order management, pricing, delivery, invoicing, and production support.",
-            "Translated business requirements into system configurations, process flows, test cases, and production-ready improvements.",
-            "Collaborated with business users, QA, finance, materials management, and engineering teams to resolve issues in business-critical systems.",
-          ].map((point) => (
-            <li key={point} className="flex items-start gap-3 text-sm text-muted-foreground">
-              <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-muted-foreground" />
-              {point}
-            </li>
-          ))}
-        </ul>
+
+        {/* Accenture - the previous deployment */}
+        <div data-accenture className="border-t border-border pt-12">
+          <div className="mb-2 font-mono text-xs uppercase tracking-[0.25em] text-muted-foreground">
+            Previous deployment
+          </div>
+          <div className="mb-8 flex flex-wrap items-baseline gap-4">
+            <h2 className="text-xl font-bold text-foreground">Accenture</h2>
+            <span className="font-mono text-sm text-muted-foreground">
+              Software Engineer, SAP S/4HANA · Feb 2021 – Sep 2022 · Hyderabad, India
+            </span>
+          </div>
+          <ul className="max-w-2xl space-y-3">
+            {[
+              "Built and supported enterprise software workflows across order management, pricing, delivery, invoicing, and production support.",
+              "Translated business requirements into system configurations, process flows, test cases, and production-ready improvements.",
+              "Collaborated with business users, QA, finance, materials management, and engineering teams to resolve issues in business-critical systems.",
+            ].map((point) => (
+              <li key={point} className="flex items-start gap-3 text-sm text-muted-foreground">
+                <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-muted-foreground" />
+                {point}
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Master_PRP §10.6 (Phases 16–18) - each interior route becomes a destination with a film-backed header (reusing the existing Higgsfield clips, zero new assets) and one signature interaction:

- **/work "The Deployment Log"**: scene-ship header; the timeline rail draws itself with scroll and nodes ignite in their tag colors; sticky role block
- **/projects "The Lab"**: scene-rag header; tag-colored cursor-spotlight + elastic tilt on cards; FLIP filter transitions
- **/about "The Human Layer"**: scene-now header; bucket-list coverage report (bar fills on scroll, done items check off); drifting interest pills

All routes stay static-prerendered, poster-first on mobile, instant under reduced-motion, no new dependencies (GSAP Flip ships inside gsap).

## Test plan

- [x] Clean production build (all routes static)
- [x] Reviewed on dev by owner
- [ ] Preview/production click-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)